### PR TITLE
fix: Make filter clear button work reliably and refactor

### DIFF
--- a/orw-deno/deno.lock
+++ b/orw-deno/deno.lock
@@ -5,6 +5,7 @@
     "jsr:@deno/loader@~0.3.2": "0.3.2",
     "jsr:@fresh/core@2.0.0-alpha.52": "2.0.0-alpha.52",
     "jsr:@fresh/plugin-tailwind@0.0.1-alpha.9": "0.0.1-alpha.9",
+    "jsr:@std/assert@1": "1.0.13",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/encoding@^1.0.10": "1.0.10",
@@ -12,6 +13,7 @@
     "jsr:@std/fs@1": "1.0.19",
     "jsr:@std/html@1": "1.0.4",
     "jsr:@std/http@^1.0.15": "1.0.20",
+    "jsr:@std/internal@^1.0.6": "1.0.10",
     "jsr:@std/internal@^1.0.9": "1.0.10",
     "jsr:@std/jsonc@1": "1.0.2",
     "jsr:@std/media-types@1": "1.1.0",
@@ -75,6 +77,12 @@
         "npm:postcss"
       ]
     },
+    "@std/assert@1.0.13": {
+      "integrity": "ae0d31e41919b12c656c742b22522c32fb26ed0cba32975cb0de2a273cb68b29",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.6"
+      ]
+    },
     "@std/bytes@1.0.6": {
       "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
     },
@@ -87,7 +95,7 @@
     "@std/fs@1.0.19": {
       "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06",
       "dependencies": [
-        "jsr:@std/internal",
+        "jsr:@std/internal@^1.0.9",
         "jsr:@std/path@^1.1.1"
       ]
     },
@@ -112,7 +120,7 @@
     "@std/path@1.1.1": {
       "integrity": "fe00026bd3a7e6a27f73709b83c607798be40e20c81dde655ce34052fd82ec76",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.9"
       ]
     },
     "@std/semver@1.0.5": {

--- a/orw-deno/islands/NavBar.tsx
+++ b/orw-deno/islands/NavBar.tsx
@@ -1,6 +1,5 @@
 // islands/NavBar.tsx - Navigation bar with real-time updates
 import { useEffect } from "preact/hooks";
-import { batch } from "@preact/signals";
 import {
   clientConfig,
   clientLists,
@@ -23,14 +22,6 @@ export default function NavBar() {
 
     return () => clearInterval(interval);
   }, []);
-
-  // Clear filter function using batch to avoid race conditions
-  const clearFilter = () => {
-    // Use batch to ensure all signal updates happen atomically
-    batch(() => {
-      filterText.value = "";
-    });
-  };
 
   const config = clientConfig.value;
   const status = clientStatus.value;
@@ -168,18 +159,18 @@ export default function NavBar() {
               onInput={(e) => filterText.value = (e.target as HTMLInputElement).value}
               onKeyDown={(e) => {
                 if (e.key === "Escape") {
-                  clearFilter();
+                  filterText.value = "";
                   (e.target as HTMLInputElement).blur();
                 }
               }}
               class="input input-bordered input-sm w-full max-w-xs pr-10"
             />
-            {filterText.value && (              <button
+            {filterText.value && (
+              <button
                 type="button"
-                onClick={(e) => {
+                onMouseDown={(e) => {
                   e.preventDefault();
-                  e.stopPropagation();
-                  clearFilter();
+                  filterText.value = "";
                 }}
                 class="absolute right-1 top-1/2 transform -translate-y-1/2 btn btn-ghost btn-xs p-1 min-h-0 h-6 w-6 z-10"
                 title="Clear filter"


### PR DESCRIPTION
The clear button for the filter input in the NavBar only worked intermittently. This was due to a race condition between the input's `blur` event and the button's `click` event when the button was clicked while the input was focused.

This commit fixes the issue by changing the event handler on the clear button from `onClick` to `onMouseDown`. By using `onMouseDown` and calling `event.preventDefault()`, the input field is prevented from losing focus when the button is clicked. This avoids the `blur` event and the associated race condition, making the clear button's behavior reliable.

This commit also refactors the component by removing the unnecessary `clearFilter` helper function and the `batch` import from `@preact/signals`, inlining the state-clearing logic directly into the event handlers.